### PR TITLE
Draft: Add implementation of stable-priceability for cardinal ballots

### DIFF
--- a/pabutools/analysis/justifiedrepresentation.py
+++ b/pabutools/analysis/justifiedrepresentation.py
@@ -55,6 +55,23 @@ def is_in_core(
                         return False
     return True
 
+def is_in_core_up_to_one(
+        instance: Instance,
+        profile: AbstractProfile,
+        sat_class: type[SatisfactionMeasure],
+        budget_allocation: Collection[Project],
+) -> bool:
+    """
+    Test if a given budget allocation is in the core up-to-one of the instance.
+    """
+    return is_in_core(
+        instance,
+        profile,
+        sat_class,
+        budget_allocation,
+        up_to_func=lambda x: max(x, default=0)
+    )
+
 
 def is_strong_EJR_approval(
     instance: Instance,

--- a/pabutools/election/ballot/approvalballot.py
+++ b/pabutools/election/ballot/approvalballot.py
@@ -140,6 +140,12 @@ class ApprovalBallot(set[Project], Ballot, AbstractApprovalBallot):
         """
         return FrozenApprovalBallot(self, name=self.name, meta=self.meta)
 
+    def supports(self, c):
+        return self.utility(c) > 0
+
+    def utility(self, c):
+        return 1 if c in self else 0
+
     # Ensures that methods returning copies of sets cast back into ApprovalBallot
     @classmethod
     def _wrap_methods(cls, methods):

--- a/pabutools/election/ballot/ballot.py
+++ b/pabutools/election/ballot/ballot.py
@@ -40,6 +40,12 @@ class AbstractBallot(ABC, Collection[Project]):
         self.meta = meta
         self.name = name
 
+    def supports(self, c):
+        raise NotImplementedError("This ballot does not support the notion of 'supporting' projects.")
+
+    def utility(self, c):
+        raise NotImplementedError("This ballot does not support the notion of 'utility' for projects.")
+
 
 class FrozenBallot(AbstractBallot, ABC):
     """

--- a/pabutools/election/ballot/cardinalballot.py
+++ b/pabutools/election/ballot/cardinalballot.py
@@ -12,6 +12,8 @@ from pabutools.election.instance import Project
 
 from pabutools.utils import Numeric
 
+import random
+
 
 class AbstractCardinalBallot(AbstractBallot, ABC, Mapping[Project, Numeric]):
     """
@@ -180,3 +182,15 @@ class CardinalBallot(dict[Project, Numeric], Ballot, AbstractCardinalBallot):
 
 
 CardinalBallot._wrap_methods(["copy", "__ior__", "__or__", "__ror__"])
+
+
+def get_random_cost_utility_cardinal_ballot(
+    projects: Collection[Project],
+    name: str = "RandomAppBallot",
+    approval_probability: float = 0.5
+) -> CardinalBallot:
+    ballot = CardinalBallot(name=name)
+    for p in projects:
+        if random.random() > approval_probability:
+            ballot[p] = p.cost
+    return ballot

--- a/pabutools/election/ballot/cardinalballot.py
+++ b/pabutools/election/ballot/cardinalballot.py
@@ -156,6 +156,12 @@ class CardinalBallot(dict[Project, Numeric], Ballot, AbstractCardinalBallot):
         """
         return FrozenCardinalBallot(self)
 
+    def supports(self, c):
+        return self.utility(c) > 0
+
+    def utility(self, c):
+        return self[c] if c in self else 0
+
     # This allows dict method returning copies of a dict to work
     @classmethod
     def _wrap_methods(cls, names):

--- a/pabutools/election/profile/cardinalprofile.py
+++ b/pabutools/election/profile/cardinalprofile.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Collection, Iterable
 
-from pabutools.election.ballot.cardinalballot import AbstractCardinalBallot
+from pabutools.election.ballot.cardinalballot import AbstractCardinalBallot, get_random_cost_utility_cardinal_ballot
 from pabutools.utils import Numeric
 
 from pabutools.election.ballot import (
@@ -457,3 +457,19 @@ CardinalMultiProfile._wrap_methods(
         "copy",
     ]
 )
+
+def get_random_cost_utility_cardinal_profile(
+    instance: Instance,
+    num_agents: int,
+    approval_probability: float = 0.5
+) -> CardinalProfile:
+    profile = CardinalProfile(instance=instance)
+    for i in range(num_agents):
+        profile.append(
+            get_random_cost_utility_cardinal_ballot(
+                instance,
+                name="RandomAppBallot {}".format(i),
+                approval_probability=approval_probability
+            )
+        )
+    return profile

--- a/tests/test_priceability.py
+++ b/tests/test_priceability.py
@@ -7,7 +7,11 @@ Module testing priceability / stable-priceability property.
 from unittest import TestCase
 
 from pabutools.analysis.priceability import priceable, validate_price_system
-from pabutools.election import Project, Instance, ApprovalProfile, ApprovalBallot
+from pabutools.election import Project, Instance, ApprovalProfile, ApprovalBallot, CardinalBallot, CardinalProfile
+
+
+def approval_ballot_to_cardinal_ballot(ballot: ApprovalBallot) -> CardinalBallot:
+    return CardinalBallot({c : 1 for c in ballot})
 
 
 class TestPriceability(TestCase):
@@ -179,3 +183,54 @@ class TestPriceability(TestCase):
         self.assertTrue(priceable(instance, profile, res.allocation, stable=True).validate())
 
         self.assertTrue(validate_price_system(instance, profile, res.allocation, res.voter_budget, res.payment_functions, stable=True))
+
+    def test_priceable_cardinal_reduces_to_approval_like_test_3(self):
+        # If cardinal profile contains only binary utilities, the implementation should give the same exact solutions.
+        # The election example is the same as in test_priceable_approval_3
+        p = [Project(str(i), cost=1) for i in range(13)]
+        instance = Instance(p[1:], budget_limit=9)
+
+        v1 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
+        print(v1)
+        v2 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
+        v3 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
+
+        v4 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
+        v5 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
+        v6 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
+
+        v7 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
+        v8 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
+        v9 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
+        profile = CardinalProfile(init=[v1, v2, v3, v4, v5, v6, v7, v8, v9])
+
+        allocation = p[1:10]
+        self.assertTrue(priceable(instance, profile, allocation).validate())
+
+        allocation = p[1:6] + p[7:9] + p[10:12]
+        self.assertTrue(priceable(instance, profile, allocation).validate())
+
+        allocation = p[1:6] + p[7:9] + p[11:12]
+        self.assertFalse(priceable(instance, profile, allocation).validate())
+
+        res = priceable(instance, profile)
+        self.assertTrue(priceable(instance, profile, res.allocation, res.voter_budget, res.payment_functions).validate())
+        self.assertTrue(priceable(instance, profile, res.allocation).validate())
+
+        self.assertTrue(validate_price_system(instance, profile, res.allocation, res.voter_budget, res.payment_functions))
+
+    # todo - implement the rest of the tests
+    def test_priceable_cardinal_reduces_to_approval_random(self):
+        pass
+
+    def test_stable_priceable_cardinal_reduces_to_approval_like_test_3(self):
+        pass
+
+    def test_stable_priceable_cardinal_reduces_to_approval_random(self):
+        pass
+
+    def test_stable_priceable_cardinal_1(self):
+        pass
+
+    def test_stable_priceable_cardinal_2(self):
+        pass

--- a/tests/test_priceability.py
+++ b/tests/test_priceability.py
@@ -1,17 +1,24 @@
 """
 Module testing priceability / stable-priceability property.
 """
-
 # fmt: off
-
+import random
 from unittest import TestCase
 
+from pabutools.analysis.justifiedrepresentation import is_in_core_up_to_one
 from pabutools.analysis.priceability import priceable, validate_price_system
-from pabutools.election import Project, Instance, ApprovalProfile, ApprovalBallot, CardinalBallot, CardinalProfile
+from pabutools.election import Project, Instance, ApprovalProfile, ApprovalBallot, CardinalBallot, CardinalProfile, \
+    get_random_approval_profile, Cost_Sat
+from pabutools.election.instance import get_random_instance
+from pabutools.election.profile.cardinalprofile import get_random_cost_utility_cardinal_profile
 
 
 def approval_ballot_to_cardinal_ballot(ballot: ApprovalBallot) -> CardinalBallot:
     return CardinalBallot({c : 1 for c in ballot})
+
+def approval_profile_to_cardinal_profile(profile: ApprovalProfile) -> CardinalProfile:
+    voters = [approval_ballot_to_cardinal_ballot(ballot) for ballot in profile]
+    return CardinalProfile(init=voters)
 
 
 class TestPriceability(TestCase):
@@ -190,19 +197,19 @@ class TestPriceability(TestCase):
         p = [Project(str(i), cost=1) for i in range(13)]
         instance = Instance(p[1:], budget_limit=9)
 
-        v1 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
-        print(v1)
-        v2 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
-        v3 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]}))
+        v1 = ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]})
+        v2 = ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]})
+        v3 = ApprovalBallot({p[1], p[2], p[3], p[4], p[5], p[6]})
 
-        v4 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
-        v5 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
-        v6 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]}))
+        v4 = ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]})
+        v5 = ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]})
+        v6 = ApprovalBallot({p[1], p[2], p[3], p[7], p[8], p[9]})
 
-        v7 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
-        v8 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
-        v9 = approval_ballot_to_cardinal_ballot(ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]}))
-        profile = CardinalProfile(init=[v1, v2, v3, v4, v5, v6, v7, v8, v9])
+        v7 = ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]})
+        v8 = ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]})
+        v9 = ApprovalBallot({p[1], p[2], p[3], p[10], p[11], p[12]})
+        approval_profile = ApprovalProfile(init=[v1, v2, v3, v4, v5, v6, v7, v8, v9])
+        profile = approval_profile_to_cardinal_profile(approval_profile)
 
         allocation = p[1:10]
         self.assertTrue(priceable(instance, profile, allocation).validate())
@@ -221,15 +228,102 @@ class TestPriceability(TestCase):
 
     # todo - implement the rest of the tests
     def test_priceable_cardinal_reduces_to_approval_random(self):
-        pass
+        for _ in range(100):
+            projects_count = random.randint(5, 15)
+            voters_count = random.randint(5, 15)
+            min_project_cost = random.randint(1, 15)
+            max_project_cost = random.randint(min_project_cost + 1, 100)
 
-    def test_stable_priceable_cardinal_reduces_to_approval_like_test_3(self):
-        pass
+            instance = get_random_instance(projects_count, min_project_cost, max_project_cost)
+            approval_profile = get_random_approval_profile(instance, voters_count)
+            cardinal_profile = approval_profile_to_cardinal_profile(approval_profile)
+
+            approval_original_res = priceable(instance, approval_profile)
+            cardinal_res_with_approval_allocation = priceable(instance, cardinal_profile, budget_allocation=approval_original_res.allocation)
+            self.assertEqual(approval_original_res.validate(), cardinal_res_with_approval_allocation.validate())
+
+            cardinal_original_res = priceable(instance, cardinal_profile)
+            approval_res_with_cardinal_allocation = priceable(instance, approval_profile, budget_allocation=cardinal_original_res.allocation)
+            self.assertEqual(cardinal_original_res.validate(), approval_res_with_cardinal_allocation.validate())
+
+    def test_stable_priceable_cardinal_reduces_to_approval_like_test_4(self):
+        # If cardinal profile contains only binary utilities, the implementation should give the same exact solutions.
+        # The election example is the same as in test_priceable_approval_4
+        p = [
+            Project("bike path", cost=700),
+            Project("outdoor gym", cost=400),
+            Project("new park", cost=250),
+            Project("new playground", cost=200),
+            Project("library for kids", cost=100),
+        ]
+        instance = Instance(p, budget_limit=1100)
+
+        v1 = ApprovalBallot({p[0], p[1]})
+        v2 = ApprovalBallot({p[0], p[1], p[2]})
+        v3 = ApprovalBallot({p[0], p[1]})
+        v4 = ApprovalBallot({p[0], p[1], p[2]})
+        v5 = ApprovalBallot({p[0], p[1], p[2]})
+        v6 = ApprovalBallot({p[0], p[1]})
+        v7 = ApprovalBallot({p[2], p[3], p[4]})
+        v8 = ApprovalBallot({p[3]})
+        v9 = ApprovalBallot({p[3], p[4]})
+        v10 = ApprovalBallot({p[2], p[3], p[4]})
+        v11 = ApprovalBallot({p[0]})
+        approval_profile = ApprovalProfile(init=[v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11])
+        profile = approval_profile_to_cardinal_profile(approval_profile)
+
+        allocation = [p[0], p[1]]
+        self.assertFalse(priceable(instance, profile, allocation, stable=True).validate())
+
+        allocation = [p[0], p[2], p[4]]
+        self.assertFalse(priceable(instance, profile, allocation, stable=True).validate())
+
+        allocation = p[1:]
+        self.assertTrue(priceable(instance, profile, allocation, stable=True).validate())
+
+        res = priceable(instance, profile, stable=True)
+        self.assertTrue(priceable(instance, profile, res.allocation, res.voter_budget, res.payment_functions, stable=True).validate())
+        self.assertTrue(priceable(instance, profile, res.allocation, stable=True).validate())
+
+        self.assertTrue(validate_price_system(instance, profile, res.allocation, res.voter_budget, res.payment_functions, stable=True))
 
     def test_stable_priceable_cardinal_reduces_to_approval_random(self):
-        pass
+        for _ in range(100):
+            projects_count = random.randint(5, 10)
+            voters_count = random.randint(5, 10)
+            min_project_cost = random.randint(1, 15)
+            max_project_cost = random.randint(min_project_cost + 1, 100)
+
+            instance = get_random_instance(projects_count, min_project_cost, max_project_cost)
+            approval_profile = get_random_approval_profile(instance, voters_count)
+            cardinal_profile = approval_profile_to_cardinal_profile(approval_profile)
+
+            approval_original_res = priceable(instance, approval_profile, stable=True)
+            cardinal_res_with_approval_allocation = priceable(instance, cardinal_profile, budget_allocation=approval_original_res.allocation, stable=True)
+            self.assertEqual(approval_original_res.validate(), cardinal_res_with_approval_allocation.validate())
+
+            cardinal_original_res = priceable(instance, cardinal_profile, stable=True)
+            approval_res_with_cardinal_allocation = priceable(instance, approval_profile, budget_allocation=cardinal_original_res.allocation, stable=True)
+            self.assertEqual(cardinal_original_res.validate(), approval_res_with_cardinal_allocation.validate())
+
+    def test_stable_priceable_implies_core_up_to_one(self):
+        for _ in range(10):
+            projects_count = random.randint(5, 10)
+            voters_count = random.randint(5, 10)
+            min_project_cost = random.randint(1, 15)
+            max_project_cost = random.randint(min_project_cost + 1, 100)
+
+            instance = get_random_instance(projects_count, min_project_cost, max_project_cost)
+            profile = get_random_cost_utility_cardinal_profile(instance, voters_count)
+
+            res = priceable(instance, profile, stable=True)
+            if res.validate():
+                self.assertTrue(is_in_core_up_to_one(instance, profile, Cost_Sat, res.allocation))
+
+
 
     def test_stable_priceable_cardinal_1(self):
+
         pass
 
     def test_stable_priceable_cardinal_2(self):


### PR DESCRIPTION
Extend functionality of **priceable** function to work not only for ApprovalBallot, but also for CardinalBallot.

Provide additional tests for stable-priceability for election with cardinal utilities, including regression tests, where CardinalBallots have binary utilities, to show that they are equivalent to working with ApprovalBallots.

Add methods **supports** and **utility** to AbstractBallot with actual implementations for CardinalBallot and ApprovalBallot. Notions of **supporting** candidates or having a particular **utility** from a candidate does not exist for OrdinalBallot, possibly subject to further work.