### PR TITLE
Fix broken references in docs

### DIFF
--- a/docs-source/source/conf.py
+++ b/docs-source/source/conf.py
@@ -27,6 +27,11 @@ extensions = [
     "enum_tools.autoenum",
 ]
 
+nitpicky = True
+nitpick_ignore_regex = [
+    (r"^py:.*$", r"^(?!pabutools\.).*")
+]
+
 add_module_names = False
 autodoc_member_order = "groupwise"
 autodoc_typehints_format = "short"

--- a/pabutools/analysis/category.py
+++ b/pabutools/analysis/category.py
@@ -17,7 +17,7 @@ def category_proportionality(
     specifically, for each category (an error is raised if not category are specified) we compute the amount of money
     dedicated to projects from the category in the budget allocation; together with the amount of money allocated to
     the category in the ballots of the voters. For each category, the average between these two scores is raised to the
-    power 2, the global average over all categories is then considered and we return the exponential of minus that
+    power 2, the global average over all categories is then considered, and we return the exponential of minus that
     value.
 
     It mostly makes sense for approval ballots, though any profile of ballots supporting the `in` operator can be used.

--- a/pabutools/analysis/mesanalytics.py
+++ b/pabutools/analysis/mesanalytics.py
@@ -146,7 +146,7 @@ def calculate_effective_supports(
     final_budget: Numeric | None = None,
 ) -> dict[Project, int]:
     """
-    Returns a dictionary of :py:class:`~pabutools.election.instance.project` and their effective support
+    Returns a dictionary of :py:class:`~pabutools.election.instance.Project` and their effective support
     in a given instance, profile and mes election. Effective support for a project is an analytical metric
     which allows to measure the ratio of initial budget received to minimal budget required to win.
     Effective support is represented in percentages.

--- a/pabutools/analysis/votersatisfaction.py
+++ b/pabutools/analysis/votersatisfaction.py
@@ -94,7 +94,7 @@ def percent_positive_satisfaction(
             Collection of projects.
         sat_class : type[:py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`]
             The class defining the satisfaction function used to measure the social welfare. It should be a class
-            inhereting from :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`.
+            inheriting from :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`.
 
     Returns
     -------

--- a/pabutools/election/profile/approvalprofile.py
+++ b/pabutools/election/profile/approvalprofile.py
@@ -328,7 +328,7 @@ def get_all_approval_profiles(
         instance : :py:class:`~pabutools.election.instance.Instance`
             The instance the profile is defined with respect to.
         num_agents : int
-            The length of the profile, i.e., the number of agents..
+            The length of the profile, i.e., the number of agents.
 
     Returns
     -------

--- a/pabutools/election/satisfaction/__init__.py
+++ b/pabutools/election/satisfaction/__init__.py
@@ -1,6 +1,5 @@
 """
-Module introducing different ways to approximate the voters' satisfaction given their ballots. See the
-see the :py:mod:`~pabutools.election.ballot` module for more details on the ballots.
+Module introducing different ways to approximate the voters' satisfaction given their ballots. See the :py:mod:`~pabutools.election.ballot` module for more details on the ballots.
 
 This module introduces general ways to define satisfaction measures together with a large set of already implemented
 satisfaction measures.

--- a/pabutools/election/satisfaction/additivesatisfaction.py
+++ b/pabutools/election/satisfaction/additivesatisfaction.py
@@ -145,7 +145,7 @@ def cardinality_sat_func(
     precomputed_values: dict,
 ) -> int:
     """
-    Computes the cardinality satisfaction for ballots. It is equal to 1 if the project is appears in the ballot and
+    Computes the cardinality satisfaction for ballots. It is equal to 1 if the project appears in the ballot and
     0 otherwise.
 
     Parameters

--- a/pabutools/rules/__init__.py
+++ b/pabutools/rules/__init__.py
@@ -8,7 +8,7 @@ The rules implemented are:
 * The method of equal shares: :py:func:`~pabutools.rules.mes.method_of_equal_shares`
 * The sequential Phragmén rule: :py:func:`~pabutools.rules.phragmen.sequential_phragmen`
 
-Given that some rules may not used up the budget as much as possible (notably the method of equal shares and the
+Given that some rules may not be used up the budget as much as possible (notably the method of equal shares and the
 sequential Phragmén rule), we also implement methods to make the outcome exhaustive. Specifically, we implemented:
 
 * The completion method by rule combination: :py:func:`~pabutools.rules.exhaustion.completion_by_rule_combination`

--- a/pabutools/rules/greedywelfare/greedywelfare_rule.py
+++ b/pabutools/rules/greedywelfare/greedywelfare_rule.py
@@ -250,8 +250,8 @@ def greedy_utilitarian_welfare(
             The profile.
         sat_class : type[:py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`]
             The class defining the satisfaction function used to measure the social welfare. It should be a class
-            inhereting from :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`.
-            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfation profile is
+            inheriting from :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`.
+            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfaction profile is
             provided, the satisfaction argument is disregarded.
         sat_profile : :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.GroupSatisfactionMeasure`
             The satisfaction profile corresponding to the instance and the profile. If no satisfaction profile is

--- a/pabutools/rules/maxwelfare.py
+++ b/pabutools/rules/maxwelfare.py
@@ -314,11 +314,11 @@ def max_additive_utilitarian_welfare(
 ) -> BudgetAllocation | list[BudgetAllocation]:
     """
     Rule returning the budget allocation(s) maximizing the utilitarian social welfare. The
-    utilitarian social welfare is defined as the sum of the satisfactin of the voters, where the
+    utilitarian social welfare is defined as the sum of the satisfaction of the voters, where the
     satisfaction is computed using the satisfaction measure given as a parameter. The satisfaction
     measure is assumed to be additive.
 
-    The outcome can be computed either via a integer linear program solver or with a primal/dual
+    The outcome can be computed either via an integer linear program solver or with a primal/dual
     approach. Note that depending on the selected algorithm, not all functionalities are supported
     (with the ILP solver ties cannot be handled while the primal/dual approach does not support
     irresolute outcomes).
@@ -331,8 +331,8 @@ def max_additive_utilitarian_welfare(
             The profile.
         sat_class : type[:py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`]
             The class defining the satisfaction function used to measure the social welfare. It should be a class
-            inhereting from pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure.
-            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfation profile is
+            inheriting from pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure.
+            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfaction profile is
             provided, the satisfaction argument is disregarded.
         sat_profile : :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.GroupSatisfactionMeasure`
             The satisfaction profile corresponding to the instance and the profile. If no satisfaction profile is

--- a/pabutools/rules/mes/mes_details.py
+++ b/pabutools/rules/mes/mes_details.py
@@ -9,8 +9,8 @@ from pabutools.utils import Numeric
 class MESAllocationDetails(AllocationDetails):
     """Class representing the details of MES rule.
     This class represents the MES details using an iteration approach: at each iteration of the MES rule some
-    crucial information is saved which allow for reconstruction of the whole run. An iteration corrosponds to one
-    call to `mes_inner_algo`, and each iteration corrosponds to one project being picked.
+    crucial information is saved which allow for reconstruction of the whole run. An iteration corresponds to one
+    call to `mes_inner_algo`, and each iteration corresponds to one project being picked.
 
     Attributes
     ----------
@@ -39,7 +39,7 @@ class MESAllocationDetails(AllocationDetails):
 
     def get_final_budget(self) -> Numeric:
         """
-        Returns the budget limt used in the final feasible MES run.
+        Returns the budget limit used in the final feasible MES run.
         """
         budget_per_voter = self.iterations[0].voters_budget
         return sum(
@@ -162,7 +162,7 @@ class MESIteration(list[MESProjectDetails]):
         project_details.discarded = True
 
     def update_project_details_as_effective_vote_count_reduced(self, project: Project):
-        """Updates the project details of the given project as having it's effective vote count reduced during this iteration."""
+        """Updates the project details of the given project as having its effective vote count reduced during this iteration."""
         project_details = self[self.index(project)]
         project_details.effective_vote_count_reduced = True
 

--- a/pabutools/rules/mes/mes_details.py
+++ b/pabutools/rules/mes/mes_details.py
@@ -130,7 +130,7 @@ class MESIteration(list[MESProjectDetails]):
             The budget of all voters at the start of the iteration. Defaults to `None`.
         voters_budget_after_selection: list[int], optional
             The budget of all voters after the selected project was covered. Defaults to `None`.
-        selected_project: :py:class:`~pabutools.electin.instance.Project`, optional
+        selected_project: :py:class:`~pabutools.election.instance.Project`, optional
             The project that was selected at the end of the iteration. Defaults to `None`.
 
     Attributes

--- a/pabutools/rules/mes/mes_rule.py
+++ b/pabutools/rules/mes/mes_rule.py
@@ -664,8 +664,8 @@ def method_of_equal_shares(
             The profile.
         sat_class : type[:py:class:`~pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure`]
             The class defining the satisfaction function used to measure the social welfare. It should be a class
-            inhereting from pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure.
-            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfation profile is
+            inheriting from pabutools.election.satisfaction.satisfactionmeasure.SatisfactionMeasure.
+            If no satisfaction is provided, a satisfaction profile needs to be provided. If a satisfaction profile is
             provided, the satisfaction argument is disregarded.
         sat_profile : :py:class:`~pabutools.election.satisfaction.satisfactionmeasure.GroupSatisfactionMeasure`
             The satisfaction profile corresponding to the instance and the profile. If no satisfaction profile is

--- a/pabutools/tiebreaking.py
+++ b/pabutools/tiebreaking.py
@@ -116,7 +116,7 @@ app_score_tie_breaking = TieBreakingRule(
     lambda inst, prof, proj: -prof.approval_score(proj)
 )
 """
-Implements tie breaking based on the approval score wher the projects with the highest number of supporters in the 
+Implements tie breaking based on the approval score where the projects with the highest number of supporters in the 
 profile is selected. Can only be applied to approval profiles.
 """
 

--- a/pabutools/visualisation/templates/mes_page_summary_template.html
+++ b/pabutools/visualisation/templates/mes_page_summary_template.html
@@ -312,7 +312,7 @@
                         <p>
                             This is the summary for the results of this participatory budgeting election decided by the Method of Equal Shares (MES). <br>
                             With this method, the total budget is virtually divided equally among the voters. <br>
-                            The following web-page outlines the process of the election and the step by step process of how each project was chosen - <a href="https://equalshares.net/explanation/">Explanation</a>. <br><br>
+                            The following web-page outlines the process of the election and the step-by-step process of how each project was chosen - <a href="https://equalshares.net/explanation/">Explanation</a>. <br><br>
                             {{ election_name}} had a total of {{ total_votes }} voters participating.<br>
                             Between these voters there was a total of {{ "{:,}".format((budget | int)) }} {{ currency }} available, of which {{ "{:,}".format((spent | int)) }} {{ currency }} was spent.<br>
                             In total, there were {{ number_of_elected_projects }} projects elected, and {{ number_of_unelected_projects }} projects not elected.<br>
@@ -352,7 +352,7 @@
             <p>This table displays at each round what project got selected in green as well as any rejected projects in white.<br>
                Further, this table features a chart in which you can hover your mouse over and compare the 
                project's final funding (blue bar) with the funding lost (red bar), where the initial funding represents the whole bar.<br>
-               Finally, each row can be expanded on to reveal more details regarding the project and its round, including expalanation on why this project got selected/rejected and a 
+               Finally, each row can be expanded on to reveal more details regarding the project and its round, including explanation on why this project got selected/rejected and a
                link to a more advanced view of how the specific round unfolded.
             </p>
             
@@ -429,14 +429,14 @@
                                     {% endfor %}
                                     <b>Other Details:</b><br>
                                     <br>
-                                    <!-- Sample expalanations -->
+                                    <!-- Sample explanations -->
                                     <div>
                                         <h4>Why was this project selected?</h4>
                                         {% if round.initial_voter_funding != round.final_voter_funding %}
                                             This project was accepted because its supporters were able to pay for the project's cost - <b>{{ "{:,}".format( (round.cost | int) ) }}</b> {{ currency }} -
                                             using the total funding available to them at the start of round {{ loop.index }} (<b>{{ "{:,.2f}".format((round.final_voter_funding | float)) }}</b> {{ currency }}). <br><br>
                                             Note that the supporters of this project initially had more funding available to them (<b>{{ "{:,.2f}".format((round.initial_voter_funding | float)) }} </b> {{ currency }}). However, this funding
-                                            was lost as these supporters had also funded projects in the previous rounds, decreasing the total funding available to them, but not to the point where the project cost exceedes the combined funds of the supporters.
+                                            was lost as these supporters had also funded projects in the previous rounds, decreasing the total funding available to them, but not to the point where the project cost exceeds the combined funds of the supporters.
                                             As a result, this project could still be afforded.<br><br>
                                             These projects and the specific funding lost can be seen below.
                                         {% else %}
@@ -517,7 +517,7 @@
                                             <b>Other Details:</b><br>
                                             <br>
 
-                                            <!-- Sample expalanations -->
+                                            <!-- Sample explanations -->
                                             <div style="text-align: left">
                                                 <h4>Why was this project not selected?</h4>
                                                 {% if rejected.initial_voter_funding >= rejected.cost %}

--- a/pabutools/visualisation/templates/mes_round_analysis_template.html
+++ b/pabutools/visualisation/templates/mes_round_analysis_template.html
@@ -255,7 +255,7 @@
                     <div class="row featurette">
                         <div class="col-5">
                           <h2 class="featurette-heading">Effective Vote Count</h2>
-                          <p class="lead">'<span class="project_name"></span>' has the highest effective vote count, as there is enough budget to support this project the project will recieve funding. 
+                          <p class="lead">'<span class="project_name"></span>' has the highest effective vote count, as there is enough budget to support this project the project will receive funding.
                             This project costs <span class="project_cost"></span>.
                             <span class="project_votes"></span> people voted for this project, at the time the project was elected it had an effective vote count of <span class="effective_vote_count"></span>.     </p>
                         </div>

--- a/pabutools/visualisation/visualisation.py
+++ b/pabutools/visualisation/visualisation.py
@@ -36,9 +36,9 @@ class MESVisualiser(Visualiser):
 
     Parameters
     ----------
-    profile : :py:class:`~pabutools.election.profile.AbstractProfile`
+    profile : :py:class:`~pabutools.election.profile.profile.AbstractProfile`
         The profile.
-    instance : Instance
+    instance : :py:class:`~pabutools.election.instance.Instance`
         The election instance.
     outcome : :py:class:`~pabutools.rules.budgetallocation.AllocationDetails`
             The outcome of the election.
@@ -489,7 +489,7 @@ class GreedyWelfareVisualiser(Visualiser):
 
     Parameters
     ----------
-    profile : :py:class:`~pabutools.election.profile.AbstractProfile`
+    profile : :py:class:`~pabutools.election.profile.profile.AbstractProfile`
         The profile.
     instance : :py:class:`~pabutools.election.instance.Instance`
         The election instance.

--- a/pabutools/visualisation/visualisation.py
+++ b/pabutools/visualisation/visualisation.py
@@ -485,7 +485,7 @@ class MESVisualiser(Visualiser):
 class GreedyWelfareVisualiser(Visualiser):
     """
     Class used to visualise the results of a Greedy Welfare election. The visualisation result
-    consits of a round by round analysis page called 'round_analysis.html'.
+    consists of a round by round analysis page called 'round_analysis.html'.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR makes Sphinx emit warnings if there's an incorrect reference to another class from the `pabutools` library.
```py
nitpicky = True
nitpick_ignore_regex = [
    (r"^py:.*$", r"^(?!pabutools\.).*")
]
```

Additionally, it removes all existing (3) such incorrect references ([example](https://comsoc-community.github.io/pabutools/reference/rules/index.html#pabutools.rules.mes.MESIteration), `selected_project`). It also fixes some typos.